### PR TITLE
Improvements

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,34 +1,3 @@
-const codeToNameMap = {
-  "COMP 60001": "Advanced Architecture",
-  "COMP 60008": "Custom Computing",
-  "COMP 60020": "Simulation and Modelling",
-  "COMP 70001": "Advanced Computer Graphics",
-  "COMP 70004": "Advanced Computer Security",
-  "COMP 70005": "Complexity",
-  "COMP 70006": "Computational Finance",
-  "COMP 70007": "Computational Optimization",
-  "COMP 70008": "Concurrent Processes",
-  "COMP 70009": "Cryptography Engineering",
-  "COMP 70010": "Deep Learning",
-  "COMP 70011": "Individual Project MEng",
-  "COMP 70015": "Mathematics for ML",
-  "COMP 70016": "Natural Language Processing",
-  "COMP 70017": "Principles of Distributed Ledgers",
-  "COMP 70018": "Privacy Engineering",
-  "COMP 70019": "Probablistic Inference",
-  "COMP 70020": "Program Analysis",
-  "COMP 70022": "Scalable Systems and Data",
-  "COMP 70023": "Scalable Software Verification",
-  "COMP 70024": "Software Reliability",
-  "COMP 70025": "Software Engineering for Industry",
-  "COMP 70028": "Reinforcement Learning",
-  "COMP 70030": "Knowledge Representation",
-  "COMP 70031": "Modal Logic for Strategic Reasoning in AI",
-  "COMP 70066": "Decentralised Finance",
-  "COMP 70067": "Robot Learning and Control",
-  "COMP 70068": "Scheduling & Resource Alloc",
-};
-
 const expandButtonSelector = "span.sbi-content";
 const courseTabSelector = "span.sbi-content";
 
@@ -50,8 +19,9 @@ const coursesObserver = new MutationObserver(function (mutations) {
     if (document.querySelector(courseTabSelector)) {
       Object.values(document.querySelectorAll(courseTabSelector)).map(
         (course) => {
-          if (course.innerText in codeToNameMap) {
-            course.innerText = codeToNameMap[course.innerText];
+          const [courseCode, courseName] = course.innerText.split(": ");
+          if (courseName) {
+            course.innerHTML = `${courseName} <small style="opacity: 0.5">(${courseCode.replace("COMP ", "")})</small>`;
           }
         }
       );

--- a/manifest.json
+++ b/manifest.json
@@ -8,5 +8,11 @@
       "matches": ["https://edstem.org/*"],
       "js": ["content.js"]
     }
+  ],
+  "action": {
+    "default_popup": "options.html"
+  },
+  "permissions": [
+    "storage"
   ]
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EdStem Enhancement Suite</title>
+    <style>
+        * {
+            font-family: sans-serif;
+        }
+
+        body {
+            min-width: 300px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Options</h1>
+    <h2>Inactive Courses <small><a href="#" id="addInactiveCourse">add</a></small></h2>
+    <ul id="inactiveCourses"></ul>
+    <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,54 @@
+const addInactiveCourseButton = document.querySelector("#addInactiveCourse");
+const inactiveCoursesList = document.querySelector("#inactiveCourses");
+
+addInactiveCourseButton.addEventListener("click", addInactiveCourse);
+
+async function loadInactiveCourses() {
+  return new Promise(resolve => {
+    chrome.storage.sync.get(["inactiveCourses"], (result) => resolve(result.inactiveCourses ? result.inactiveCourses : []));
+  })
+}
+
+async function saveInactiveCourses(inactiveCourses) {
+  return new Promise(resolve => {
+    chrome.storage.sync.set({ inactiveCourses }, () => resolve());
+  })
+}
+
+async function reloadInactiveCourses() {
+  const inactiveCourses = await loadInactiveCourses();
+  inactiveCoursesList.innerHTML = '';
+
+  for (const inactiveCourse of inactiveCourses) {
+    const li = document.createElement("li");
+    li.textContent = inactiveCourse + " ";
+
+    const remove = document.createElement('a');
+    remove.addEventListener('click', () => removeInactiveCourse(inactiveCourse));
+    remove.href = '#';
+    remove.textContent = "remove";
+    li.appendChild(remove);
+
+    inactiveCoursesList.appendChild(li);
+  }
+}
+
+async function addInactiveCourse() {
+  const courseName = prompt("Enter a course name");
+  if (courseName) {
+    const inactiveCourses = await loadInactiveCourses();
+    inactiveCourses.push(courseName);
+    await saveInactiveCourses(inactiveCourses);
+    await reloadInactiveCourses();
+  }
+}
+
+async function removeInactiveCourse(inactiveCourse) {
+  await saveInactiveCourses(
+    (await loadInactiveCourses())
+      .filter(c => c !== inactiveCourse)
+  );
+  await reloadInactiveCourses();
+}
+
+reloadInactiveCourses();


### PR DESCRIPTION
Thanks for this extension, the course naming was really annoying.

It seems Mark updated the course codes to include names a couple of days ago which broke this extension. I still prefer the extension though since the codes still add useless noise in the sidebar. I've fixed it by removing the hardcoded map - now it splits the content by `:` to find the name.

I've also added a feature to define a list of inactive courses, which I find quite useful to clearly indicate last term's courses in the sidebar.

![image](https://user-images.githubusercontent.com/10169241/150683561-abbec9e2-6240-4b7f-9353-49dbf947fd54.png)

![image](https://user-images.githubusercontent.com/10169241/150683591-560aa634-5114-417c-a57a-39b3137ebcc5.png)
